### PR TITLE
Attempt for issue #9

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 Changelog
 =========
 
+Development - Unreleased
+------------------------
+
+* Added some Sass functions to escape a value from quotes;
+* Enabled quote escape on ``get-props-to-json`` and ``get-values-to-json`` functions to avoid invalid JSON, close #9;
+
 Version 0.5.0 - 2019/05/05
 --------------------------
 

--- a/py_css_styleguide/scss/_styleguide_helpers.scss
+++ b/py_css_styleguide/scss/_styleguide_helpers.scss
@@ -1,5 +1,50 @@
 /* Helper functions from py-css-styleguide==0.5.0 */
 
+/// Replace every occurences of a character with a substition string.
+/// Useful to strip some characters.
+///
+/// @arg {String} $string [null]
+///     A string to parse, this must be a real string type.
+///
+/// @arg {String} $search [null]
+///     Character to replace.
+///
+/// @arg {String} $replace ['']
+///     String which will replace searched character.
+///
+/// @return {String} - Modified string following given arguments.
+///
+@function _strip-token($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + _strip-token(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}
+
+/// Enforce safe string with escaping simple and double quote
+///
+/// @arg {String} $string [null]
+///     A string to parse, `#{}` is used on given value so it always enforce
+///     given value will be a real string type. (So you may give it a list or
+///     map or whatever).
+///
+/// @arg {Bool} $apply [true]
+///   If false, will return the given string unmodified.
+///
+/// @return {String} - Escaped string if $apply is enabled.
+///
+@function _safe-string($string, $apply: true) {
+  @if $apply {
+    $value: #{$string};
+    @return _strip-token(_strip-token($value, '"', $replace: '\\u0022'), "'", $replace: '\\u0027');
+  }
+
+  @return $string;
+}
+
 ///
 /// Convert a list to a string
 /// Copied from https://hugogiraudel.com/2013/08/08/advanced-sass-list-functions/
@@ -112,10 +157,15 @@
 /// @arg {String} $prefix ['']
 ///   A string to preprend to each item.
 ///
-@function get-values-to-json($map, $prefix: "") {
+/// @arg {Bool} $safe-string [true]
+///   If true, every item value are escaped from single and double quotes. This
+///   is often required to avoid invalid JSON with values which contain quotes.
+///
+@function get-values-to-json($map, $prefix: "", $safe-string: true) {
     $values: ();
     @each $name in map-values($map) {
-        $values: append($values, $prefix+$name);
+        $val: _safe-string($name, $apply: $safe-string);
+        $values: append($values, $prefix+$val);
     }
     @return list-to-json($values);
 }
@@ -153,10 +203,15 @@
 /// @arg {String} $prefix ['']
 ///   A string to preprend to each item.
 ///
-@function get-props-to-json($map, $property, $prefix: "") {
+/// @arg {Bool} $safe-string [true]
+///   If true, every item value are escaped from single and double quotes. This
+///   is often required to avoid invalid JSON with values which contain quotes.
+///
+@function get-props-to-json($map, $property, $prefix: "", $safe-string: true) {
     $values: ();
     @each $name, $scheme in $map {
-        $values: append($values, $prefix+map-get($scheme, $property));
+        $val: _safe-string(map-get($scheme, $property), $apply: $safe-string);
+        $values: append($values, $prefix+$val);
     }
     @return list-to-json($values);
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 ;;
 [metadata]
 name = py-css-styleguide
-version = 0.5.0
+version = 0.5.1-pre.2
 description = CSS Manifest driven styleguide for your project
 long_description = file:README.rst
 long_description_content_type = text/x-rst

--- a/tests/040_sass_helper.py
+++ b/tests/040_sass_helper.py
@@ -85,6 +85,11 @@ def test_boussole_compile(fixtures_settings, temp_builds_dir):
                     "selector": ".bg-grey-gradient",
                     "background": "linear-gradient(#ffffff, #ffffff 85%, #404040)",
                     "font_color": "#000000"
+                },
+                "with-image": {
+                    "selector": ".bg-with-image",
+                    "background": "url(u0022foo/bar.pngu0022)",
+                    "font_color": "#000000"
                 }
             }
         },

--- a/tests/data_fixtures/sass/css/styleguide_manifest.css
+++ b/tests/data_fixtures/sass/css/styleguide_manifest.css
@@ -11,10 +11,10 @@
 
 .styleguide-reference-schemes {
   --splitter: "json-list";
-  --keys: '["black", "grey", "white", "grey-gradient"]';
-  --selector: '[".bg-black", ".bg-grey", ".bg-white", ".bg-grey-gradient"]';
-  --background: '["#000000", "#404040", "#ffffff", "linear-gradient(#ffffff, #ffffff 85%, #404040)"]';
-  --font_color: '["#ffffff", "#ffffff", "#000000", "#000000"]';
+  --keys: '["black", "grey", "white", "grey-gradient", "with-image"]';
+  --selector: '[".bg-black", ".bg-grey", ".bg-white", ".bg-grey-gradient", ".bg-with-image"]';
+  --background: '["#000000", "#404040", "#ffffff", "linear-gradient(#ffffff, #ffffff 85%, #404040)", "url(\u0022foo/bar.png\u0022)"]';
+  --font_color: '["#ffffff", "#ffffff", "#000000", "#000000", "#000000"]';
 }
 
 .styleguide-reference-borders {

--- a/tests/data_fixtures/sass/scss/_settings.scss
+++ b/tests/data_fixtures/sass/scss/_settings.scss
@@ -29,6 +29,10 @@ $schemes-colors: (
         background: linear-gradient($white, $white 85%, $grey),
         font-color: $black,
     ),
+    with-image: (
+        background: url("foo/bar.png"),
+        font-color: $black,
+    ),
 );
 
 $borders: (


### PR DESCRIPTION
Added function to escape string to avoid invalid JSON from serializer parsing and use them in `get-props-to-json` to avoid a bug with complex `background` rule values.

This is working from what i tested, it need some tests to ensure it does not break anything and maybe to apply escape in another "to-json" function (like `get-values-to-json`, `get-names-to-json`? `get-names-to-json`?)

# Todo

- [x] Test coverage;
- [x] Apply escape on other "to-json" functions;
